### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/fn.el
+++ b/fn.el
@@ -5,7 +5,7 @@
 ;; Author: Troy Pracy
 ;; Keywords: functional
 ;; Version: 0.1.2
-;; Package-Requires: ((emacs "24") (cl-lib "0.5") (dash "2.12.1") (dash-functional "1.2.0"))
+;; Package-Requires: ((emacs "24") (cl-lib "0.5") (dash "2.18.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl-lib))
-(require 'dash-functional)
+(require 'dash)
 
 
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218